### PR TITLE
Add stored procedure support

### DIFF
--- a/src/Faithlife.Data/DbConnector.cs
+++ b/src/Faithlife.Data/DbConnector.cs
@@ -133,6 +133,29 @@ namespace Faithlife.Data
 		public DbConnectorCommand Command(string text, params (string Name, object? Value)[] parameters) => new DbConnectorCommand(this, text, DbParameters.Create(parameters));
 
 		/// <summary>
+		/// Creates a new command.
+		/// </summary>
+		/// <param name="text">The text of the command.</param>
+		/// <param name="isStoredProcedure">Whether or not this command is a stored procedure.</param>
+		public DbConnectorCommand Command(string text, bool isStoredProcedure) => new DbConnectorCommand(this, text, default, isStoredProcedure);
+
+		/// <summary>
+		/// Creates a new command.
+		/// </summary>
+		/// <param name="text">The text of the command.</param>
+		/// <param name="isStoredProcedure">Whether or not this command is a stored procedure.</param>
+		/// <param name="parameters">The command parameters.</param>
+		public DbConnectorCommand Command(string text, bool isStoredProcedure, DbParameters parameters) => new DbConnectorCommand(this, text, parameters, isStoredProcedure);
+
+		/// <summary>
+		/// Creates a new command.
+		/// </summary>
+		/// <param name="text">The text of the command.</param>
+		/// <param name="isStoredProcedure">Whether or not this command is a stored procedure.</param>
+		/// <param name="parameters">The command parameters.</param>
+		public DbConnectorCommand Command(string text, bool isStoredProcedure, params (string Name, object? Value)[] parameters) => new DbConnectorCommand(this, text, DbParameters.Create(parameters), isStoredProcedure);
+
+		/// <summary>
 		/// Disposes the connector.
 		/// </summary>
 		/// <seealso cref="DisposeAsync" />

--- a/src/Faithlife.Data/DbConnector.cs
+++ b/src/Faithlife.Data/DbConnector.cs
@@ -137,7 +137,7 @@ namespace Faithlife.Data
 		/// </summary>
 		/// <param name="text">The text of the command.</param>
 		/// <param name="isStoredProcedure">Whether or not this command is a stored procedure.</param>
-		public DbConnectorCommand Command(string text, bool isStoredProcedure) => new DbConnectorCommand(this, text, default, isStoredProcedure);
+		public DbConnectorCommand StoredProcedure(string text) => new DbConnectorCommand(this, text, default, isStoredProcedure);
 
 		/// <summary>
 		/// Creates a new command.

--- a/src/Faithlife.Data/DbConnector.cs
+++ b/src/Faithlife.Data/DbConnector.cs
@@ -136,21 +136,21 @@ namespace Faithlife.Data
 		/// Creates a new command to access a stored procedure.
 		/// </summary>
 		/// <param name="text">The name of the stored procedure.</param>
-		public DbConnectorCommand StoredProcedure(string text) => new DbConnectorCommand(this, text, default, isStoredProcedure: true);
+		public DbConnectorCommand StoredProcedure(string text) => new DbConnectorCommand(this, text, default, CommandType.StoredProcedure);
 
 		/// <summary>
 		/// Creates a new command.
 		/// </summary>
 		/// <param name="text">The name of the stored procedure.</param>
 		/// <param name="parameters">The command parameters.</param>
-		public DbConnectorCommand StoredProcedure(string text, DbParameters parameters) => new DbConnectorCommand(this, text, parameters, isStoredProcedure: true);
+		public DbConnectorCommand StoredProcedure(string text, DbParameters parameters) => new DbConnectorCommand(this, text, parameters, CommandType.StoredProcedure);
 
 		/// <summary>
 		/// Creates a new command.
 		/// </summary>
 		/// <param name="text">The name of the stored procedure.</param>
 		/// <param name="parameters">The command parameters.</param>
-		public DbConnectorCommand StoredProcedure(string text, params (string Name, object? Value)[] parameters) => new DbConnectorCommand(this, text, DbParameters.Create(parameters), isStoredProcedure: true);
+		public DbConnectorCommand StoredProcedure(string text, params (string Name, object? Value)[] parameters) => new DbConnectorCommand(this, text, DbParameters.Create(parameters), CommandType.StoredProcedure);
 
 		/// <summary>
 		/// Disposes the connector.

--- a/src/Faithlife.Data/DbConnector.cs
+++ b/src/Faithlife.Data/DbConnector.cs
@@ -133,27 +133,24 @@ namespace Faithlife.Data
 		public DbConnectorCommand Command(string text, params (string Name, object? Value)[] parameters) => new DbConnectorCommand(this, text, DbParameters.Create(parameters));
 
 		/// <summary>
-		/// Creates a new command.
+		/// Creates a new command to access a stored procedure.
 		/// </summary>
-		/// <param name="text">The text of the command.</param>
-		/// <param name="isStoredProcedure">Whether or not this command is a stored procedure.</param>
-		public DbConnectorCommand StoredProcedure(string text) => new DbConnectorCommand(this, text, default, isStoredProcedure);
+		/// <param name="text">The name of the stored procedure.</param>
+		public DbConnectorCommand StoredProcedure(string text) => new DbConnectorCommand(this, text, default, isStoredProcedure: true);
 
 		/// <summary>
 		/// Creates a new command.
 		/// </summary>
-		/// <param name="text">The text of the command.</param>
-		/// <param name="isStoredProcedure">Whether or not this command is a stored procedure.</param>
+		/// <param name="text">The name of the stored procedure.</param>
 		/// <param name="parameters">The command parameters.</param>
-		public DbConnectorCommand Command(string text, bool isStoredProcedure, DbParameters parameters) => new DbConnectorCommand(this, text, parameters, isStoredProcedure);
+		public DbConnectorCommand StoredProcedure(string text, DbParameters parameters) => new DbConnectorCommand(this, text, parameters, isStoredProcedure: true);
 
 		/// <summary>
 		/// Creates a new command.
 		/// </summary>
-		/// <param name="text">The text of the command.</param>
-		/// <param name="isStoredProcedure">Whether or not this command is a stored procedure.</param>
+		/// <param name="text">The name of the stored procedure.</param>
 		/// <param name="parameters">The command parameters.</param>
-		public DbConnectorCommand Command(string text, bool isStoredProcedure, params (string Name, object? Value)[] parameters) => new DbConnectorCommand(this, text, DbParameters.Create(parameters), isStoredProcedure);
+		public DbConnectorCommand StoredProcedure(string text, params (string Name, object? Value)[] parameters) => new DbConnectorCommand(this, text, DbParameters.Create(parameters), isStoredProcedure: true);
 
 		/// <summary>
 		/// Disposes the connector.

--- a/src/Faithlife.Data/DbConnectorCommand.cs
+++ b/src/Faithlife.Data/DbConnectorCommand.cs
@@ -272,7 +272,7 @@ namespace Faithlife.Data
 		/// <summary>
 		/// Caches the command.
 		/// </summary>
-		public DbConnectorCommand Cache() => new DbConnectorCommand(Connector, Text, Parameters, CommandType == CommandType.StoredProcedure, isCached: true);
+		public DbConnectorCommand Cache() => new DbConnectorCommand(Connector, Text, Parameters, CommandType, isCached: true);
 
 		/// <summary>
 		/// Creates an <see cref="IDbCommand" /> from the text and parameters.
@@ -296,12 +296,12 @@ namespace Faithlife.Data
 			return DoCreate(connection);
 		}
 
-		internal DbConnectorCommand(DbConnector connector, string text, DbParameters parameters, bool isStoredProcedure = false, bool isCached = false)
+		internal DbConnectorCommand(DbConnector connector, string text, DbParameters parameters, CommandType commandType = CommandType.Text, bool isCached = false)
 		{
 			Connector = connector;
 			Text = text;
 			Parameters = parameters;
-			CommandType = isStoredProcedure ? CommandType.StoredProcedure : CommandType.Text;
+			CommandType = commandType;
 			IsCached = isCached;
 		}
 

--- a/src/Faithlife.Data/DbConnectorCommand.cs
+++ b/src/Faithlife.Data/DbConnectorCommand.cs
@@ -31,7 +31,7 @@ namespace Faithlife.Data
 		public DbConnector Connector { get; }
 
 		/// <summary>
-		/// True if this command is a stored procedure.
+		/// The <c><see cref="CommandType"/></c> of the command.
 		/// </summary>
 		public CommandType CommandType { get; }
 

--- a/src/Faithlife.Data/DbConnectorCommand.cs
+++ b/src/Faithlife.Data/DbConnectorCommand.cs
@@ -387,8 +387,8 @@ namespace Faithlife.Data
 				command = CreateNewCommand();
 			}
 
-			if (IsStoredProcedure)
-				command.CommandType = CommandType.StoredProcedure;
+			if (CommandType != CommandType.Text)
+				command.CommandType = CommandType;
 
 			foreach (var (name, value) in parameters)
 			{

--- a/src/Faithlife.Data/DbConnectorCommand.cs
+++ b/src/Faithlife.Data/DbConnectorCommand.cs
@@ -33,7 +33,7 @@ namespace Faithlife.Data
 		/// <summary>
 		/// True if this command is a stored procedure.
 		/// </summary>
-		public bool IsStoredProcedure { get; }
+		public CommandType CommandType { get; }
 
 		/// <summary>
 		/// True after <see cref="Cache"/> is called.
@@ -272,7 +272,7 @@ namespace Faithlife.Data
 		/// <summary>
 		/// Caches the command.
 		/// </summary>
-		public DbConnectorCommand Cache() => new DbConnectorCommand(Connector, Text, Parameters, IsStoredProcedure, isCached: true);
+		public DbConnectorCommand Cache() => new DbConnectorCommand(Connector, Text, Parameters, CommandType == CommandType.StoredProcedure, isCached: true);
 
 		/// <summary>
 		/// Creates an <see cref="IDbCommand" /> from the text and parameters.
@@ -301,7 +301,7 @@ namespace Faithlife.Data
 			Connector = connector;
 			Text = text;
 			Parameters = parameters;
-			IsStoredProcedure = isStoredProcedure;
+			CommandType = isStoredProcedure ? CommandType.StoredProcedure : CommandType.Text;
 			IsCached = isCached;
 		}
 

--- a/src/Faithlife.Data/DbConnectorCommand.cs
+++ b/src/Faithlife.Data/DbConnectorCommand.cs
@@ -31,6 +31,11 @@ namespace Faithlife.Data
 		public DbConnector Connector { get; }
 
 		/// <summary>
+		/// True if this command is a stored procedure.
+		/// </summary>
+		public bool IsStoredProcedure { get; }
+
+		/// <summary>
 		/// True after <see cref="Cache"/> is called.
 		/// </summary>
 		public bool IsCached { get; }
@@ -267,7 +272,7 @@ namespace Faithlife.Data
 		/// <summary>
 		/// Caches the command.
 		/// </summary>
-		public DbConnectorCommand Cache() => new DbConnectorCommand(Connector, Text, Parameters, isCached: true);
+		public DbConnectorCommand Cache() => new DbConnectorCommand(Connector, Text, Parameters, IsStoredProcedure, isCached: true);
 
 		/// <summary>
 		/// Creates an <see cref="IDbCommand" /> from the text and parameters.
@@ -291,11 +296,12 @@ namespace Faithlife.Data
 			return DoCreate(connection);
 		}
 
-		internal DbConnectorCommand(DbConnector connector, string text, DbParameters parameters, bool isCached = false)
+		internal DbConnectorCommand(DbConnector connector, string text, DbParameters parameters, bool isStoredProcedure = false, bool isCached = false)
 		{
 			Connector = connector;
 			Text = text;
 			Parameters = parameters;
+			IsStoredProcedure = isStoredProcedure;
 			IsCached = isCached;
 		}
 
@@ -380,6 +386,9 @@ namespace Faithlife.Data
 			{
 				command = CreateNewCommand();
 			}
+
+			if (IsStoredProcedure)
+				command.CommandType = CommandType.StoredProcedure;
 
 			foreach (var (name, value) in parameters)
 			{

--- a/src/Faithlife.Data/DbConnectorCommand.cs
+++ b/src/Faithlife.Data/DbConnectorCommand.cs
@@ -314,6 +314,7 @@ namespace Faithlife.Data
 		private IDbCommand DoCreate(IDbConnection connection)
 		{
 			var commandText = Text;
+			var commandType = CommandType;
 
 			var parameters = Parameters;
 			var index = 0;
@@ -387,9 +388,6 @@ namespace Faithlife.Data
 				command = CreateNewCommand();
 			}
 
-			if (CommandType != CommandType.Text)
-				command.CommandType = CommandType;
-
 			foreach (var (name, value) in parameters)
 			{
 				if (!(value is IDbDataParameter dbParameter))
@@ -409,6 +407,7 @@ namespace Faithlife.Data
 			{
 				var newCommand = connection.CreateCommand();
 				newCommand.CommandText = commandText;
+				newCommand.CommandType = commandType;
 				if (transaction != null)
 					newCommand.Transaction = transaction;
 				return newCommand;

--- a/tests/Faithlife.Data.Tests/DbConnectorTests.cs
+++ b/tests/Faithlife.Data.Tests/DbConnectorTests.cs
@@ -322,6 +322,18 @@ namespace Faithlife.Data.Tests
 			(await connector.Command("select Name from Items order by ItemId;").QueryAsync<string>()).Should().Equal("one", "two", "three");
 		}
 
+		public void StoredProcedureUnitTests()
+		{
+			using var connector = CreateConnector();
+			var createCommand = connector.Command("create table Items (ItemId integer primary key, Name text not null);");
+			createCommand.IsStoredProcedure.Should().Be(false);
+			createCommand.Execute().Should().Be(0);
+			connector.Command("insert into Items (Name) values (@item1);", ("item1", "one")).IsStoredProcedure.Should().Be(false);
+
+			connector.Command("values (1);", isStoredProcedure: true).IsStoredProcedure.Should().Be(true);
+			connector.Command("values (@two);", isStoredProcedure: true, ("two", 2)).IsStoredProcedure.Should().Be(true);
+		}
+
 		private static async Task<IReadOnlyList<T>> ToListAsync<T>(IAsyncEnumerable<T> items)
 		{
 			var list = new List<T>();

--- a/tests/Faithlife.Data.Tests/DbConnectorTests.cs
+++ b/tests/Faithlife.Data.Tests/DbConnectorTests.cs
@@ -322,16 +322,19 @@ namespace Faithlife.Data.Tests
 			(await connector.Command("select Name from Items order by ItemId;").QueryAsync<string>()).Should().Equal("one", "two", "three");
 		}
 
+		[Test]
 		public void StoredProcedureUnitTests()
 		{
 			using var connector = CreateConnector();
 			var createCommand = connector.Command("create table Items (ItemId integer primary key, Name text not null);");
-			createCommand.IsStoredProcedure.Should().Be(false);
+			createCommand.CommandType.Should().Be(CommandType.Text);
 			createCommand.Execute().Should().Be(0);
-			connector.Command("insert into Items (Name) values (@item1);", ("item1", "one")).IsStoredProcedure.Should().Be(false);
+			connector.Command("insert into Items (Name) values (@item1);", ("item1", "one")).CommandType.Should().Be(CommandType.Text);
 
-			connector.Command("values (1);", isStoredProcedure: true).IsStoredProcedure.Should().Be(true);
-			connector.Command("values (@two);", isStoredProcedure: true, ("two", 2)).IsStoredProcedure.Should().Be(true);
+			var storedProcedureCommand = connector.StoredProcedure("values (1);");
+			storedProcedureCommand.CommandType.Should().Be(CommandType.StoredProcedure);
+			Invoking(() => storedProcedureCommand.Execute()).Should().Throw<ArgumentException>("CommandType must be Text. (Parameter 'value')");
+			connector.StoredProcedure("values (@two);", ("two", 2)).CommandType.Should().Be(CommandType.StoredProcedure);
 		}
 
 		private static async Task<IReadOnlyList<T>> ToListAsync<T>(IAsyncEnumerable<T> items)


### PR DESCRIPTION
Resolves #5.

The parameter I added to each `DbConnector.Command` overload is `bool isStoredProcedure`. Should I stick with that, or would it be better for the parameter to be <code><a href="https://docs.microsoft.com/en-us/dotnet/api/system.data.commandtype?view=net-5.0">CommandType</a> commandType = CommandType.Text</code> just in case you want to support additional command types in the future? There's only one other type, and it's only supported by OLE DB, but you never know.

This also adds a new property to `DbConnectorCommand`, `public bool IsStoredProcedure`. Similar to above, this could instead be implemented as `public CommandType CommandType` if desired.

And finally, these are the lines added to `DoCreate`:

```c#
if (IsStoredProcedure)
	command.CommandType = CommandType.StoredProcedure;
```

-----

I wrote some unit tests, just to test whether `IsStoredProcedure` is being set correctly, but I'm not sure how to test these functionally, since your other tests use SQLite, which [doesn't support stored procedures](https://stackoverflow.com/questions/3335162/creating-stored-procedure-and-sqlite). Should I brainstorm a way to use a different SQL system to test this part, or not bother?