### PR TITLE
Add a helper to use FormattableString for text and parameters.

### DIFF
--- a/src/Faithlife.Data/DbConnector.cs
+++ b/src/Faithlife.Data/DbConnector.cs
@@ -133,6 +133,12 @@ namespace Faithlife.Data
 		public DbConnectorCommand Command(string text, params (string Name, object? Value)[] parameters) => new DbConnectorCommand(this, text, DbParameters.Create(parameters));
 
 		/// <summary>
+		/// Creates a new command.
+		/// </summary>
+		/// <param name="textAndParameters">The text and parameters of the command.</param>
+		public DbConnectorCommand Command((string Text, DbParameters Parameters) textAndParameters) => new DbConnectorCommand(this, textAndParameters.Text, textAndParameters.Parameters);
+
+		/// <summary>
 		/// Disposes the connector.
 		/// </summary>
 		/// <seealso cref="DisposeAsync" />

--- a/src/Faithlife.Data/DbParameterizer.cs
+++ b/src/Faithlife.Data/DbParameterizer.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using Faithlife.Utility;
+using static System.FormattableString;
+
+namespace Faithlife.Data
+{
+	/// <summary>
+	/// Converts <c>FormattableString</c> into text and <c>DbParameters</c>.
+	/// </summary>
+	public static class DbParameterizer
+	{
+		/// <summary>
+		/// Converts <c>FormattableString</c> into text and <c>DbParameters</c>.
+		/// </summary>
+		public static (string Text, DbParameters Parameters) Sql(FormattableString sql)
+		{
+			if (sql is null)
+				throw new ArgumentNullException(nameof(sql));
+			var argumentCount = sql.ArgumentCount;
+			if (argumentCount > c_maxParameterCount)
+				throw new ArgumentException("Too many parameters", nameof(sql));
+			if (argumentCount == 0)
+				return (sql.Format, DbParameters.Empty);
+			var text = string.Format(CultureInfo.InvariantCulture, sql.Format, s_parameterPlaceholders[argumentCount - 1].Value);
+			var parameters = DbParameters.Create(s_parameterNames.Take(sql.ArgumentCount).Zip(sql.GetArguments()));
+			return (text, parameters);
+		}
+
+		private const int c_maxParameterCount = 100;
+		private static readonly IReadOnlyList<string> s_parameterNames = Enumerable.Range(0, c_maxParameterCount).Select(i => Invariant($"p{i}")).ToArray();
+		private static readonly IReadOnlyList<string> s_allParameterPlaceholders = s_parameterNames.Select(p => Invariant($"@{p}")).ToArray();
+		private static readonly IReadOnlyList<Lazy<object[]>> s_parameterPlaceholders = Enumerable.Range(0, c_maxParameterCount).Select(i => new Lazy<object[]>(() =>
+			{
+				var arr = new object[i + 1];
+				for (var j = 0; j < arr.Length; j++)
+					arr[j] = s_allParameterPlaceholders[j];
+				return arr;
+			}, LazyThreadSafetyMode.PublicationOnly)).ToArray();
+	}
+}

--- a/src/Faithlife.Data/Faithlife.Data.csproj
+++ b/src/Faithlife.Data/Faithlife.Data.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Faithlife.Reflection" Version="1.0.1" />
+    <PackageReference Include="Faithlife.Utility" Version="0.10.1" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">

--- a/tests/Faithlife.Data.Tests/DbConnectorTests.cs
+++ b/tests/Faithlife.Data.Tests/DbConnectorTests.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Faithlife.Data.BulkInsert;
 using FluentAssertions;
 using NUnit.Framework;
+using static Faithlife.Data.DbParameterizer;
 using static FluentAssertions.FluentActions;
 
 namespace Faithlife.Data.Tests
@@ -101,6 +102,18 @@ namespace Faithlife.Data.Tests
 			connector.Command("create table Items (ItemId integer primary key, Name text not null);").Execute().Should().Be(0);
 			connector.Command("insert into Items (Name) values (@item1); insert into Items (Name) values (@item2);",
 				("item1", "one"), ("item2", "two")).Execute().Should().Be(2);
+			connector.Command("select Name from Items where Name like @like;",
+				DbParameters.Create("like", "t%")).QueryFirst<string>().Should().Be("two");
+		}
+
+		[Test]
+		public void ParameterizerTests()
+		{
+			using var connector = CreateConnector();
+			connector.Command("create table Items (ItemId integer primary key, Name text not null);").Execute().Should().Be(0);
+			var item1 = "one";
+			var item2 = "two";
+			connector.Command(Sql($"insert into Items (Name) values ({item1}); insert into Items (Name) values ({item2});")).Execute().Should().Be(2);
 			connector.Command("select Name from Items where Name like @like;",
 				DbParameters.Create("like", "t%")).QueryFirst<string>().Should().Be("two");
 		}


### PR DESCRIPTION
This allows using `FormattableString` to encapsulate command text and parameters, reducing redundancy and increasing readability.

Example:
```csharp
var item1 = "one";
var item2 = "two";
connector.Command(Sql($"insert into Items (Name) values ({item1}); insert into Items (Name) values ({item2});")).Execute();
```

Here,
```csharp
connector.Command(Sql($"insert into Items (Name) values ({item1}); insert into Items (Name) values ({item2});"))
```
is the equivalent of
```csharp
connector.Command("insert into Items (Name) values (@p0); insert into Items (Name) values (@p1);", ("p0", item1), ("p1", "two"))
```

Using an explicit static method to convert the `FormattableString` to text and parameters makes it easier to see in code review that it's not a SQL injection vulnerability.

`Command` does not get an overload that takes a `FormattableString`, and `Sql` doesn't take a `string`, which avoids some of the potential problems, e.g. being able to pull the command argument into a local with `var`.
```csharp
// textAndParameters is a tuple
var textAndParameters = Sql($"insert into Items (Name) values ({item1}); insert into Items (Name) values ({item2});");
connector.Command(textAndParameters).Execute();
```
```csharp
// textAndParameters is a string
var textAndParameters = $"insert into Items (Name) values ({item1}); insert into Items (Name) values ({item2});");
// this will fail to compile because Sql doesn't take a string
connector.Command(Sql(textAndParameters)).Execute();
```
