### PR TITLE
Support Sql.Join and Sql.Empty.

### DIFF
--- a/src/Faithlife.Data/SqlFormatting/Sql.cs
+++ b/src/Faithlife.Data/SqlFormatting/Sql.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 
 namespace Faithlife.Data.SqlFormatting
 {
@@ -15,6 +17,18 @@ namespace Faithlife.Data.SqlFormatting
 		public static Sql Format(FormattableString formattableString) => new FormatSql(formattableString ?? throw new ArgumentNullException(nameof(formattableString)));
 
 		/// <summary>
+		/// Joins SQL fragments with the specified separator.
+		/// </summary>
+		public static Sql Join(string separator, params Sql[] sqls) =>
+			new JoinSql(separator ?? throw new ArgumentNullException(nameof(separator)), sqls ?? throw new ArgumentNullException(nameof(sqls)));
+
+		/// <summary>
+		/// Joins SQL fragments with the specified separator.
+		/// </summary>
+		public static Sql Join(string separator, IEnumerable<Sql> sqls) =>
+			new JoinSql(separator ?? throw new ArgumentNullException(nameof(separator)), AsReadOnlyList(sqls ?? throw new ArgumentNullException(nameof(sqls))));
+
+		/// <summary>
 		/// Creates SQL for an arbitrarily named parameter with the specified value.
 		/// </summary>
 		public static Sql Param(object? value) => new ParamSql(value);
@@ -26,11 +40,21 @@ namespace Faithlife.Data.SqlFormatting
 
 		internal abstract string Render(SqlContext context);
 
+		private static IReadOnlyList<T> AsReadOnlyList<T>(IEnumerable<T> items) => (items as IReadOnlyList<T>) ?? items.ToList();
+
 		private sealed class FormatSql : Sql
 		{
 			public FormatSql(FormattableString formattableString) => m_formattableString = formattableString;
 			internal override string Render(SqlContext context) => m_formattableString.ToString(new SqlFormatProvider(context));
 			private readonly FormattableString m_formattableString;
+		}
+
+		private sealed class JoinSql : Sql
+		{
+			public JoinSql(string separator, IReadOnlyList<Sql> sqls) => (m_separator, m_sqls) = (separator, sqls);
+			internal override string Render(SqlContext context) => string.Join(m_separator, m_sqls.Select(x => x.Render(context)));
+			private readonly string m_separator;
+			private readonly IReadOnlyList<Sql> m_sqls;
 		}
 
 		private sealed class ParamSql : Sql

--- a/src/Faithlife.Data/SqlFormatting/Sql.cs
+++ b/src/Faithlife.Data/SqlFormatting/Sql.cs
@@ -12,6 +12,11 @@ namespace Faithlife.Data.SqlFormatting
 	public abstract class Sql
 	{
 		/// <summary>
+		/// An empty SQL string.
+		/// </summary>
+		public static readonly Sql Empty = Sql.Raw("");
+
+		/// <summary>
 		/// Creates SQL from a formatted string.
 		/// </summary>
 		public static Sql Format(FormattableString formattableString) => new FormatSql(formattableString ?? throw new ArgumentNullException(nameof(formattableString)));

--- a/tests/Faithlife.Data.Tests/SqlFormatting/SqlSyntaxTests.cs
+++ b/tests/Faithlife.Data.Tests/SqlFormatting/SqlSyntaxTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using Faithlife.Data.SqlFormatting;
 using FluentAssertions;
 using NUnit.Framework;
@@ -106,6 +107,22 @@ namespace Faithlife.Data.Tests.SqlFormatting
 		{
 			var tableName = "widgets";
 			Invoking(() => Render(Sql.Format($"select * from {tableName:xyzzy}"))).Should().Throw<FormatException>();
+		}
+
+		[Test]
+		public void JoinParams()
+		{
+			var (text, parameters) = Render(Sql.Join(", ", Sql.Param(42), Sql.Param(-42)));
+			text.Should().Be("@fdp0, @fdp1");
+			parameters.Should().Equal(("fdp0", 42), ("fdp1", -42));
+		}
+
+		[Test]
+		public void JoinEnumerable()
+		{
+			var (text, parameters) = Render(Sql.Join(", ", new[] { 42, -42 }.Select(x => Sql.Param(x))));
+			text.Should().Be("@fdp0, @fdp1");
+			parameters.Should().Equal(("fdp0", 42), ("fdp1", -42));
 		}
 
 		private static (string Text, DbParameters Parameters) Render(Sql sql) => SqlSyntax.Default.Render(sql);

--- a/tests/Faithlife.Data.Tests/SqlFormatting/SqlSyntaxTests.cs
+++ b/tests/Faithlife.Data.Tests/SqlFormatting/SqlSyntaxTests.cs
@@ -19,6 +19,14 @@ namespace Faithlife.Data.Tests.SqlFormatting
 			Invoking(() => Render(null!)).Should().Throw<ArgumentNullException>();
 		}
 
+		[Test]
+		public void EmptySql()
+		{
+			var (text, parameters) = Render(Sql.Empty);
+			text.Should().Be("");
+			parameters.Should().BeEmpty();
+		}
+
 		[TestCase("")]
 		[TestCase("select * from widgets")]
 		public void RawSql(string raw)
@@ -88,7 +96,7 @@ namespace Faithlife.Data.Tests.SqlFormatting
 		[TestCase(42)]
 		public void FormatSql(int? id)
 		{
-			var whereSql = id is null ? Sql.Raw("") : Sql.Format($"where id = {Sql.Param(id)}");
+			var whereSql = id is null ? Sql.Empty : Sql.Format($"where id = {Sql.Param(id)}");
 			var limit = 10;
 			var (text, parameters) = Render(Sql.Format($"select * from {Sql.Raw("widgets")} {whereSql} limit {limit}"));
 			if (id is null)
@@ -132,7 +140,7 @@ namespace Faithlife.Data.Tests.SqlFormatting
 					sqls.Add(Sql.Format($"width = {width}"));
 				if (height != null)
 					sqls.Add(Sql.Format($"height = {height}"));
-				var whereSql = sqls.Count == 0 ? Sql.Raw("") : Sql.Format($"where {Sql.Join(" and ", sqls)}");
+				var whereSql = sqls.Count == 0 ? Sql.Empty : Sql.Format($"where {Sql.Join(" and ", sqls)}");
 				return Sql.Format($"select * from widgets {whereSql};");
 			}
 		}


### PR DESCRIPTION
I don't love the naming conflict with an actual `JOIN` in SQL, but it's better than trying to come up with another name for joining strings and hoping library users can figure it out. I think reusing names from the `String` class for identical concepts makes the most sense.