### PR TITLE
Drop support for format specifiers.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -356,23 +356,15 @@ connector.Command(
     ).Execute();
 ```
 
-
-SQL text and paramters can be composed using the [`Sql`](Faithlife.Data.SqlFormatting/Sql.md) class. Non-parameterized SQL can be expressed using [`Sql.Raw()`](Faithlife.Data.SqlFormatting/Sql/Raw.md) or the `raw` format specifier.
+SQL text and paramters can be composed using the [`Sql`](Faithlife.Data.SqlFormatting/Sql.md) class. Non-parameterized SQL can be expressed using [`Sql.Raw()`](Faithlife.Data.SqlFormatting/Sql/Raw.md).
 
 ```csharp
-IReadOnlyList<WidgetDto> GetWidgets(DbConnector connector, double? minHeight = default)
+IReadOnlyList<WidgetDto> GetWidgets(DbConnector connector,
+    double? minHeight = null, string[]? fields = null)
 {
     var whereSql = minHeight is null ? Sql.Raw("") : Sql.Format($"where height >= {minHeight}");
-    return connector.Command(Sql.Format($"select * from widgets {whereSql};"))
-        .Query<WidgetDto>();
-}
-```
-
-```csharp
-IReadOnlyList<WidgetDto> GetWidgets(DbConnector connector, string[]? fields = default)
-{
-    var fieldsFragment = fields is null ? "*" : string.Join(", ", fields);
-    return connector.Command(Sql.Format($"select {fieldsFragment:raw} from widgets;"))
+    var fieldsSql = Sql.Raw(fields is null ? "*" : string.Join(", ", fields));
+    return connector.Command(Sql.Format($"select {fieldsSql} from widgets {whereSql};"))
         .Query<WidgetDto>();
 }
 ```

--- a/src/Faithlife.Data/SqlFormatting/Sql.cs
+++ b/src/Faithlife.Data/SqlFormatting/Sql.cs
@@ -55,21 +55,9 @@ namespace Faithlife.Data.SqlFormatting
 
 			public string Format(string? format, object? arg, IFormatProvider formatProvider)
 			{
-				switch (format)
-				{
-					case "param":
-						return m_context.RenderParam(arg);
-
-					case "raw":
-						if (arg is string stringValue)
-							return stringValue;
-						throw new FormatException("Format 'raw' can only be used with strings.");
-
-					default:
-						if (format is object)
-							throw new FormatException($"Format '{format}' is not supported.");
-						return arg is Sql sql ? sql.Render(m_context) : m_context.RenderParam(arg);
-				}
+				if (format is object)
+					throw new FormatException($"Format specifier '{format}' is not supported.");
+				return arg is Sql sql ? sql.Render(m_context) : m_context.RenderParam(arg);
 			}
 
 			private readonly SqlContext m_context;

--- a/tests/Faithlife.Data.Tests/DbConnectorTests.cs
+++ b/tests/Faithlife.Data.Tests/DbConnectorTests.cs
@@ -136,7 +136,7 @@ namespace Faithlife.Data.Tests
 			var item1 = "one";
 			var item2 = "two";
 			connector.Command(Sql.Format(
-				$"insert into Items (Name) values ({item1:param}); insert into Items (Name) values ({item2:param});")).Execute().Should().Be(2);
+				$"insert into Items (Name) values ({item1}); insert into Items (Name) values ({item2});")).Execute().Should().Be(2);
 			connector.Command("select Name from Items where Name like @like;",
 				DbParameters.Create("like", "t%")).QueryFirst<string>().Should().Be("two");
 		}

--- a/tests/Faithlife.Data.Tests/MySqlTests.cs
+++ b/tests/Faithlife.Data.Tests/MySqlTests.cs
@@ -32,8 +32,8 @@ namespace Faithlife.Data.Tests
 			var sprocName = nameof(SprocInOutTest);
 
 			using var connector = CreateConnector();
-			connector.Command(Sql.Format($"drop procedure if exists {sprocName:raw};")).Execute();
-			connector.Command(Sql.Format($"create procedure {sprocName:raw} (inout Value int) begin set Value = Value * Value; end;")).Execute();
+			connector.Command(Sql.Format($"drop procedure if exists {Sql.Raw(sprocName)};")).Execute();
+			connector.Command(Sql.Format($"create procedure {Sql.Raw(sprocName)} (inout Value int) begin set Value = Value * Value; end;")).Execute();
 
 			var param = new MySqlParameter { DbType = DbType.Int32, Direction = ParameterDirection.InputOutput, Value = 11 };
 			connector.StoredProcedure(sprocName, ("Value", param)).Execute();
@@ -46,8 +46,8 @@ namespace Faithlife.Data.Tests
 			var sprocName = nameof(SprocInTest);
 
 			using var connector = CreateConnector();
-			connector.Command(Sql.Format($"drop procedure if exists {sprocName:raw};")).Execute();
-			connector.Command(Sql.Format($"create procedure {sprocName:raw} (in Value int) begin select Value, Value * Value; end;")).Execute();
+			connector.Command(Sql.Format($"drop procedure if exists {Sql.Raw(sprocName)};")).Execute();
+			connector.Command(Sql.Format($"create procedure {Sql.Raw(sprocName)} (in Value int) begin select Value, Value * Value; end;")).Execute();
 
 			connector.StoredProcedure(sprocName, ("Value", 11)).QuerySingle<(int, long)>().Should().Be((11, 121));
 		}

--- a/tests/Faithlife.Data.Tests/SqlFormatting/SqlSyntaxTests.cs
+++ b/tests/Faithlife.Data.Tests/SqlFormatting/SqlSyntaxTests.cs
@@ -51,30 +51,6 @@ namespace Faithlife.Data.Tests.SqlFormatting
 		}
 
 		[Test]
-		public void FormatRaw()
-		{
-			var tableName = "widgets";
-			var (text, parameters) = Render(Sql.Format($"select * from {tableName:raw}"));
-			text.Should().Be("select * from widgets");
-			parameters.Should().BeEmpty();
-		}
-
-		[Test]
-		public void FormatSqlRawNotString()
-		{
-			var tableName = Sql.Raw("widgets");
-			Invoking(() => Render(Sql.Format($"select * from {tableName:raw}"))).Should().Throw<FormatException>();
-		}
-
-		[Test]
-		public void FormatExplicitParam()
-		{
-			var (text, parameters) = Render(Sql.Format($"select * from widgets where id in ({42:param}, {-42:param})"));
-			text.Should().Be("select * from widgets where id in (@fdp0, @fdp1)");
-			parameters.Should().Equal(("fdp0", 42), ("fdp1", -42));
-		}
-
-		[Test]
 		public void FormatImplicitParam()
 		{
 			var (text, parameters) = Render(Sql.Format($"select * from widgets where id in ({42}, {-42})"));


### PR DESCRIPTION
No need to also support `x:raw` when `Sql.Raw(x)` is almost as short, is less confusing, and doesn't annoy code analysis tools with non-standard format specifiers.