### PR TITLE
Fix "Collection parameters" heading link

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -75,7 +75,7 @@ With a `DbConnector`, you can:
 * Efficiently access only the first record of the query result with [`QueryFirst()`](Faithlife.Data/DbConnectorCommand/QueryFirst.md), [`QuerySingleOrDefault()`](Faithlife.Data/DbConnectorCommand/QuerySingleOrDefault.md), etc.
 * Access the database synchronously or asynchronously with cancellation support, e.g. [`Query()`](Faithlife.Data/DbConnectorCommand/Query.md) vs. [`QueryAsync()`](Faithlife.Data/DbConnectorCommand/QueryAsync.md).
 * Read multiple result sets from multi-statement commands with [`QueryMultiple()`](Faithlife.Data/DbConnectorCommand/QueryMultiple.md).
-* Expand [collection parameters](#parameters-from-collections) to a list of numbered parameters for easier `IN` support.
+* Expand [collection parameters](#collection-parameters) to a list of numbered parameters for easier `IN` support.
 * Use [bulk insert](#bulk-insert) to easily and efficiently insert multiple rows into a table.
 * Execute stored procedures with [`DbConnector.StoredProcedure()`](Faithlife.Data/DbConnector/StoredProcedure.md).
 * [Cache](#cached-commands) and/or [prepare](#prepared-commands) commands for possible performance improvements.


### PR DESCRIPTION
It took me longer than I care to admit to find the [Collection parameters](https://faithlife.github.io/FaithlifeData/#collection-parameters) section after the link in question didn't take me there. Not sure why I didn't start by searching for other instances of "collection" on the page, rather than assuming that the section must no longer exist and heading to the repo to try and figure out when it was removed, but... Oh well. This'll prevent anyone else from making the same mistake in the future.