### PR TITLE
Avoid invalid cast on int -> bool conversion.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>1.22.1</VersionPrefix>
+    <VersionPrefix>1.22.2</VersionPrefix>
     <PackageValidationBaselineVersion>1.22.0</PackageValidationBaselineVersion>
     <LangVersion>13.0</LangVersion>
     <Nullable>enable</Nullable>

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## 1.22.2
+
+* Fix DataRecordExtensions behavior for boolean fields.
+
 ## 1.22.1
 
 * Throw `InvalidOperationException` when `Sql.List`, `Sql.Tuple`, `Sql.ParamList`, or `Sql.ParamTuple` generate an empty SQL fragment.

--- a/src/Faithlife.Data/DbValueTypeInfo.cs
+++ b/src/Faithlife.Data/DbValueTypeInfo.cs
@@ -4,6 +4,7 @@ using System.Data;
 using System.Data.Common;
 using System.Diagnostics.CodeAnalysis;
 using System.Dynamic;
+using System.Globalization;
 using System.Reflection;
 
 namespace Faithlife.Data;
@@ -47,7 +48,7 @@ internal static class DbValueTypeInfo
 		[typeof(double)] = DbValueTypeStrategy.CastValue,
 		[typeof(float)] = DbValueTypeStrategy.CastValue,
 		[typeof(decimal)] = DbValueTypeStrategy.CastValue,
-		[typeof(bool)] = DbValueTypeStrategy.CastValue,
+		[typeof(bool)] = DbValueTypeStrategy.Convert,
 		[typeof(Guid)] = DbValueTypeStrategy.CastValue,
 		[typeof(DateTime)] = DbValueTypeStrategy.CastValue,
 		[typeof(DateTimeOffset)] = DbValueTypeStrategy.CastValue,
@@ -256,6 +257,25 @@ internal sealed class DbValueTypeInfo<T> : IDbValueTypeInfo
 			var bytes = new byte[byteCount];
 			record.GetBytes(index, 0, bytes, 0, byteCount);
 			return (T) (object) new MemoryStream(bytes, 0, byteCount, writable: false);
+		}
+		else if (m_strategy == DbValueTypeStrategy.Convert)
+		{
+			var value = record.GetValue(index);
+			if (value == DBNull.Value)
+			{
+				if (m_nullableType is null)
+					throw new InvalidOperationException($"Failed to cast null to {Type.FullName}.");
+				return default!;
+			}
+
+			try
+			{
+				return (T) Convert.ChangeType(value, m_coreType, CultureInfo.InvariantCulture);
+			}
+			catch (Exception exception) when (exception is ArgumentException || exception is InvalidCastException)
+			{
+				throw new InvalidOperationException($"Failed to cast {value?.GetType().FullName} to {Type.FullName}.", exception);
+			}
 		}
 		else
 		{

--- a/src/Faithlife.Data/DbValueTypeStrategy.cs
+++ b/src/Faithlife.Data/DbValueTypeStrategy.cs
@@ -10,4 +10,5 @@ internal enum DbValueTypeStrategy
 	Dynamic,
 	Dictionary,
 	Stream,
+	Convert,
 }

--- a/tests/Faithlife.Data.Tests/DataRecordExtensionsTests.cs
+++ b/tests/Faithlife.Data.Tests/DataRecordExtensionsTests.cs
@@ -16,7 +16,7 @@ internal sealed class DataRecordExtensionsTests
 	{
 		using var connection = GetOpenConnection();
 		using var command = connection.CreateCommand();
-		command.CommandText = "select TheText, TheInteger, TheReal, TheBlob from items;";
+		command.CommandText = "select TheText, TheInteger, TheReal, TheBlob, TheBool from items;";
 		using var reader = command.ExecuteReader();
 
 		// get non-nulls
@@ -35,7 +35,7 @@ internal sealed class DataRecordExtensionsTests
 	{
 		using var connection = GetOpenConnection();
 		using var command = connection.CreateCommand();
-		command.CommandText = "select TheText, TheInteger, TheReal, TheBlob from items;";
+		command.CommandText = "select TheText, TheInteger, TheReal, TheBlob, TheBool from items;";
 		using var reader = command.ExecuteReader();
 
 		// get non-nulls
@@ -56,7 +56,7 @@ internal sealed class DataRecordExtensionsTests
 	{
 		using var connection = GetOpenConnection();
 		using var command = connection.CreateCommand();
-		command.CommandText = "select TheText, TheInteger, TheReal, TheBlob from items;";
+		command.CommandText = "select TheText, TheInteger, TheReal, TheBlob, TheBool from items;";
 		using var reader = command.ExecuteReader();
 
 		// get non-nulls
@@ -77,7 +77,7 @@ internal sealed class DataRecordExtensionsTests
 	{
 		using var connection = GetOpenConnection();
 		using var command = connection.CreateCommand();
-		command.CommandText = "select TheText, TheInteger, TheReal, TheBlob from items;";
+		command.CommandText = "select TheText, TheInteger, TheReal, TheBlob, TheBool from items;";
 		using var reader = command.ExecuteReader();
 
 		// get non-nulls
@@ -98,15 +98,15 @@ internal sealed class DataRecordExtensionsTests
 	{
 		using var connection = GetOpenConnection();
 		using var command = connection.CreateCommand();
-		command.CommandText = "select TheText, TheInteger, TheReal, TheBlob from items;";
+		command.CommandText = "select TheText, TheInteger, TheReal, TheBlob, TheBool from items;";
 		using var reader = command.ExecuteReader();
 
 		reader.Read().Should().BeTrue();
 
 		Invoking(() => reader.Get<ItemDto>(-1, 2)).Should().Throw<ArgumentException>();
 		Invoking(() => reader.Get<ItemDto>(2, -1)).Should().Throw<ArgumentException>();
-		Invoking(() => reader.Get<ItemDto>(4, 1)).Should().Throw<ArgumentException>();
-		Invoking(() => reader.Get<ItemDto>(5, 0)).Should().Throw<ArgumentException>();
+		Invoking(() => reader.Get<ItemDto>(5, 1)).Should().Throw<ArgumentException>();
+		Invoking(() => reader.Get<ItemDto>(6, 0)).Should().Throw<ArgumentException>();
 	}
 
 	[Test]
@@ -114,7 +114,7 @@ internal sealed class DataRecordExtensionsTests
 	{
 		using var connection = GetOpenConnection();
 		using var command = connection.CreateCommand();
-		command.CommandText = "select TheText, TheInteger, TheReal, TheBlob from items;";
+		command.CommandText = "select TheText, TheInteger, TheReal, TheBlob, TheBool from items;";
 		using var reader = command.ExecuteReader();
 
 		reader.Read().Should().BeTrue();
@@ -128,7 +128,7 @@ internal sealed class DataRecordExtensionsTests
 	{
 		using var connection = GetOpenConnection();
 		using var command = connection.CreateCommand();
-		command.CommandText = "select TheText, TheInteger, TheReal, TheBlob from items;";
+		command.CommandText = "select TheText, TheInteger, TheReal, TheBlob, TheBool from items;";
 		using var reader = command.ExecuteReader();
 
 		reader.Read().Should().BeTrue();
@@ -143,7 +143,7 @@ internal sealed class DataRecordExtensionsTests
 	{
 		using var connection = GetOpenConnection();
 		using var command = connection.CreateCommand();
-		command.CommandText = "select TheText, TheInteger, TheReal, TheBlob from items;";
+		command.CommandText = "select TheText, TheInteger, TheReal, TheBlob, TheBool from items;";
 		using var reader = command.ExecuteReader();
 
 		// get non-nulls
@@ -162,7 +162,7 @@ internal sealed class DataRecordExtensionsTests
 	{
 		using var connection = GetOpenConnection();
 		using var command = connection.CreateCommand();
-		command.CommandText = "select TheText, TheInteger, TheReal, TheBlob from items;";
+		command.CommandText = "select TheText, TheInteger, TheReal, TheBlob, TheBool from items;";
 		using var reader = command.ExecuteReader();
 
 		// get non-nulls
@@ -184,7 +184,7 @@ internal sealed class DataRecordExtensionsTests
 	{
 		using var connection = GetOpenConnection();
 		using var command = connection.CreateCommand();
-		command.CommandText = "select TheText, TheInteger, TheReal, TheBlob from items;";
+		command.CommandText = "select TheText, TheInteger, TheReal, TheBlob, TheBool from items;";
 		using var reader = command.ExecuteReader();
 
 		// get non-nulls
@@ -192,16 +192,16 @@ internal sealed class DataRecordExtensionsTests
 
 		reader.Get<(string?, long, double)>(0, 3)
 			.Should().Be((s_dto.TheText, s_dto.TheInteger, s_dto.TheReal));
-		reader.Get<(string?, long, double)>(..^1)
+		reader.Get<(string?, long, double)>(..^2)
 			.Should().Be((s_dto.TheText, s_dto.TheInteger, s_dto.TheReal));
 
 		// get nulls
 		reader.Read().Should().BeTrue();
 
-		reader.Get<(string?, long?, double?)>(0, 3)
-			.Should().Be((null, null, null));
-		reader.Get<(string?, long?, double?)>(..3)
-			.Should().Be((null, null, null));
+		reader.Get<(string?, long?, double?, byte[]?, bool?)>(0, 5)
+			.Should().Be((null, null, null, null, null));
+		reader.Get<(string?, long?, double?, byte[]?, bool?)>(..5)
+			.Should().Be((null, null, null, null, null));
 	}
 
 	[Test]
@@ -209,17 +209,17 @@ internal sealed class DataRecordExtensionsTests
 	{
 		using var connection = GetOpenConnection();
 		using var command = connection.CreateCommand();
-		command.CommandText = "select TheText, TheInteger, TheReal, TheBlob from items;";
+		command.CommandText = "select TheText, TheInteger, TheReal, TheBlob, TheBool from items;";
 		using var reader = command.ExecuteReader();
 
 		// get non-nulls
 		reader.Read().Should().BeTrue();
 
 		// DTO
-		reader.Get<ItemDto>(0, 4).Should().BeEquivalentTo(s_dto);
+		reader.Get<ItemDto>(0, 5).Should().BeEquivalentTo(s_dto);
 		reader.Get<ItemDto>(0, 1).Should().BeEquivalentTo(new ItemDto { TheText = s_dto.TheText });
 		reader.Get<ItemDto>(0, 0).Should().BeNull();
-		reader.Get<ItemDto>(4, 0).Should().BeNull();
+		reader.Get<ItemDto>(5, 0).Should().BeNull();
 
 		// tuple with DTO
 		var tuple = reader.Get<(string, ItemDto, byte[])>(0, 4);
@@ -292,22 +292,22 @@ internal sealed class DataRecordExtensionsTests
 	{
 		using var connection = GetOpenConnection();
 		using var command = connection.CreateCommand();
-		command.CommandText = "select TheText, TheInteger, TheReal, TheBlob from items;";
+		command.CommandText = "select TheText, TheInteger, TheReal, TheBlob, TheBool from items;";
 		using var reader = command.ExecuteReader();
 
 		// get non-nulls
 		reader.Read().Should().BeTrue();
 
 		// record (compare by members because the TheBlob is compared by reference in .Equals())
-		reader.Get<ItemRecord>(0, 4).Should().BeEquivalentTo(s_record, x => x.ComparingByMembers<ItemRecord>());
-		reader.Get<ItemRecord>(0, 1).Should().BeEquivalentTo(new ItemRecord(s_record.TheText, default, default, default), x => x.ComparingByMembers<ItemRecord>());
+		reader.Get<ItemRecord>(0, 5).Should().BeEquivalentTo(s_record, x => x.ComparingByMembers<ItemRecord>());
+		reader.Get<ItemRecord>(0, 1).Should().BeEquivalentTo(new ItemRecord(s_record.TheText, default, default, default, default), x => x.ComparingByMembers<ItemRecord>());
 		reader.Get<ItemRecord>(0, 0).Should().BeNull();
 		reader.Get<ItemRecord>(4, 0).Should().BeNull();
 
 		// tuple with record
 		var tuple = reader.Get<(string, ItemRecord, byte[])>(0, 4);
 		tuple.Item1.Should().Be(s_record.TheText);
-		tuple.Item2.Should().BeEquivalentTo(new ItemRecord(default, s_record.TheInteger, s_record.TheReal, default), x => x.ComparingByMembers<ItemRecord>());
+		tuple.Item2.Should().BeEquivalentTo(new ItemRecord(default, s_record.TheInteger, s_record.TheReal, default, default), x => x.ComparingByMembers<ItemRecord>());
 		tuple.Item3.Should().Equal(s_record.TheBlob);
 
 		// tuple with two records (needs NULL terminator)
@@ -363,7 +363,7 @@ internal sealed class DataRecordExtensionsTests
 	{
 		using var connection = GetOpenConnection();
 		using var command = connection.CreateCommand();
-		command.CommandText = "select TheText, TheInteger, TheReal, TheBlob from items;";
+		command.CommandText = "select TheText, TheInteger, TheReal, TheBlob, TheBool from items;";
 		using var reader = command.ExecuteReader();
 
 		// get non-nulls
@@ -395,7 +395,7 @@ internal sealed class DataRecordExtensionsTests
 	{
 		using var connection = GetOpenConnection();
 		using var command = connection.CreateCommand();
-		command.CommandText = "select TheText, TheInteger, TheReal, TheBlob from items;";
+		command.CommandText = "select TheText, TheInteger, TheReal, TheBlob, TheBool from items;";
 		using var reader = command.ExecuteReader();
 
 		// get non-nulls
@@ -419,7 +419,7 @@ internal sealed class DataRecordExtensionsTests
 	{
 		using var connection = GetOpenConnection();
 		using var command = connection.CreateCommand();
-		command.CommandText = "select TheText, TheInteger, TheReal, TheBlob from items;";
+		command.CommandText = "select TheText, TheInteger, TheReal, TheBlob, TheBool from items;";
 		using var reader = command.ExecuteReader();
 
 		// get non-nulls
@@ -454,7 +454,7 @@ internal sealed class DataRecordExtensionsTests
 	{
 		using var connection = GetOpenConnection();
 		using var command = connection.CreateCommand();
-		command.CommandText = "select TheText, TheInteger, TheReal, TheBlob from items;";
+		command.CommandText = "select TheText, TheInteger, TheReal, TheBlob, TheBool from items;";
 		using var reader = command.ExecuteReader();
 
 		reader.Read().Should().BeTrue();
@@ -466,13 +466,13 @@ internal sealed class DataRecordExtensionsTests
 	{
 		using var connection = GetOpenConnection();
 		using var command = connection.CreateCommand();
-		command.CommandText = "select TheText, TheInteger, TheReal, TheBlob from items;";
+		command.CommandText = "select TheText, TheInteger, TheReal, TheBlob, TheBool from items;";
 		using var reader = command.ExecuteReader();
 
 		reader.Read().Should().BeTrue();
 		reader.Get<long>(1).Should().Be(s_dto.TheInteger);
 		reader.Get<long>("TheInteger").Should().Be(s_dto.TheInteger);
-		reader.Get<long>(^3).Should().Be(s_dto.TheInteger);
+		reader.Get<long>(^4).Should().Be(s_dto.TheInteger);
 	}
 
 	[Test]
@@ -480,7 +480,7 @@ internal sealed class DataRecordExtensionsTests
 	{
 		using var connection = GetOpenConnection();
 		using var command = connection.CreateCommand();
-		command.CommandText = "select TheText, TheInteger, TheReal, TheBlob from items;";
+		command.CommandText = "select TheText, TheInteger, TheReal, TheBlob, TheBool from items;";
 		using var reader = command.ExecuteReader();
 
 		reader.Read().Should().BeTrue();
@@ -495,7 +495,7 @@ internal sealed class DataRecordExtensionsTests
 	{
 		using var connection = GetOpenConnection();
 		using var command = connection.CreateCommand();
-		command.CommandText = "select TheText, TheInteger, TheReal, TheBlob from items;";
+		command.CommandText = "select TheText, TheInteger, TheReal, TheBlob, TheBool from items;";
 		using var reader = command.ExecuteReader();
 
 		reader.Read().Should().BeTrue();
@@ -511,19 +511,19 @@ internal sealed class DataRecordExtensionsTests
 
 		using (var command = connection.CreateCommand())
 		{
-			command.CommandText = "create table Items (TheText text null, TheInteger integer null, TheReal real null, TheBlob blob null);";
+			command.CommandText = "create table Items (TheText text null, TheInteger integer null, TheReal real null, TheBlob blob null, TheBool integer null);";
 			command.ExecuteNonQuery();
 		}
 
 		using (var command = connection.CreateCommand())
 		{
-			command.CommandText = "insert into Items (TheText, TheInteger, TheReal, TheBlob) values ('hey', 42, 3.1415, X'01FE');";
+			command.CommandText = "insert into Items (TheText, TheInteger, TheReal, TheBlob, TheBool) values ('hey', 42, 3.1415, X'01FE', 1);";
 			command.ExecuteNonQuery();
 		}
 
 		using (var command = connection.CreateCommand())
 		{
-			command.CommandText = "insert into Items (TheText, TheInteger, TheReal, TheBlob) values (null, null, null, null);";
+			command.CommandText = "insert into Items (TheText, TheInteger, TheReal, TheBlob, TheBool) values (null, null, null, null, null);";
 			command.ExecuteNonQuery();
 		}
 
@@ -536,6 +536,7 @@ internal sealed class DataRecordExtensionsTests
 		public long TheInteger { get; set; }
 		public double TheReal { get; set; }
 		public byte[]? TheBlob { get; set; }
+		public bool TheBool { get; set; }
 	}
 
 	private sealed class CustomColumnDto
@@ -545,7 +546,7 @@ internal sealed class DataRecordExtensionsTests
 	}
 
 #pragma warning disable CA1801, SA1313
-	private sealed record ItemRecord(string? TheText, long TheInteger, double TheReal, byte[]? TheBlob, long TheOptionalInteger = 42);
+	private sealed record ItemRecord(string? TheText, long TheInteger, double TheReal, byte[]? TheBlob, bool? TheBool, long TheOptionalInteger = 42);
 #pragma warning restore CA1801, SA1313
 
 	private sealed record NonPositionalRecord
@@ -578,11 +579,13 @@ internal sealed class DataRecordExtensionsTests
 		TheInteger = 42L,
 		TheReal = 3.1415,
 		TheBlob = new byte[] { 0x01, 0xFE },
+		TheBool = true,
 	};
 
 	private static readonly ItemRecord s_record = new(
 		TheText: "hey",
 		TheInteger: 42L,
 		TheReal: 3.1415,
-		TheBlob: new byte[] { 0x01, 0xFE });
+		TheBlob: new byte[] { 0x01, 0xFE },
+		TheBool: true);
 }

--- a/tests/Faithlife.Data.Tests/DbParametersTests.cs
+++ b/tests/Faithlife.Data.Tests/DbParametersTests.cs
@@ -67,7 +67,7 @@ internal sealed class DbParametersTests
 	public void CreateManyWithOneName()
 	{
 		DbParameters.FromMany("one", new object?[] { 1, "two", null }).Should().Equal(("one_0", 1), ("one_1", "two"), ("one_2", null));
-		DbParameters.FromMany((int i) => $"fancy*{2 * i + 1}", new object?[] { 3.14, false }).Should().Equal(("fancy*1", 3.14), ("fancy*3", false));
+		DbParameters.FromMany(i => $"fancy*{2 * i + 1}", new object?[] { 3.14, false }).Should().Equal(("fancy*1", 3.14), ("fancy*3", false));
 	}
 
 	[Test]
@@ -75,7 +75,7 @@ internal sealed class DbParametersTests
 	{
 		DbParameters.FromDto(new { one = 1 }).AddDto(new HasTwo()).Should().Equal(("one", 1), ("Two", 2));
 		DbParameters.FromDto("Thing", new { one = 1, Two = 2 }).Should().Equal(("Thing_one", 1), ("Thing_Two", 2));
-		DbParameters.FromDto((string prop) => $"it's {prop}", new { one = 1, Two = 2 }).Should().Equal(("it's one", 1), ("it's Two", 2));
+		DbParameters.FromDto(prop => $"it's {prop}", new { one = 1, Two = 2 }).Should().Equal(("it's one", 1), ("it's Two", 2));
 	}
 
 	[Test]
@@ -83,7 +83,7 @@ internal sealed class DbParametersTests
 	{
 		DbParameters.FromDtos(new object[] { new { zero = 0, one = 1 }, new HasTwo() }).Should().Equal(("zero_0", 0), ("one_0", 1), ("Two_1", 2));
 		DbParameters.FromDtos("very", new object[] { new { zero = 0, one = 1 }, new HasTwo() }).Should().Equal(("very_zero_0", 0), ("very_one_0", 1), ("very_Two_1", 2));
-		DbParameters.FromDtos((string prop, int i) => $"{prop}? more like {(i + 1) * 100}", new object[] { new { zero = 0, one = 1 }, new HasTwo() }).Should().Equal(("zero? more like 100", 0), ("one? more like 100", 1), ("Two? more like 200", 2));
+		DbParameters.FromDtos((prop, i) => $"{prop}? more like {(i + 1) * 100}", new object[] { new { zero = 0, one = 1 }, new HasTwo() }).Should().Equal(("zero? more like 100", 0), ("one? more like 100", 1), ("Two? more like 200", 2));
 	}
 
 	[Test]
@@ -95,9 +95,7 @@ internal sealed class DbParametersTests
 	}
 
 	[Test]
-	public void Add()
-	{
-		default(DbParameters)
+	public void Add() => default(DbParameters)
 			.Add("one", 1)
 			.Add(("two", 2L))
 			.Add()
@@ -105,16 +103,15 @@ internal sealed class DbParametersTests
 			.Add(new[] { ("five", 5) })
 			.Add(new Dictionary<string, int> { { "six", 6 } })
 			.AddMany("seven", new object?[] { 7, "8", null })
-			.AddMany((int i) => $"ten*{2 * i + 1}", new object?[] { 10.0, false })
+			.AddMany(i => $"ten*{2 * i + 1}", new object?[] { 10.0, false })
 			.AddDto(new { twelve = 12 })
 			.AddDto("the", new { thirteen = 13 })
 			.AddDto(name => $"Why @{name}?", new { fourteen = 14 })
 			.AddDtos(new object[] { new { fifteen = 15, sixteen = 16 }, new { seventeen = 17 } })
 			.AddDtos("stop", new object[] { new { eighteen = 18, nineteen = 19 }, new { twenty = 20 } })
-			.AddDtos((string prop, int i) => $"I don't want to write any more {prop}ing numbers ({i + 1})", new object[] { new { twenty_one = 21, twenty_two = 22 }, new { twenty_three = 23 } })
+			.AddDtos((prop, i) => $"I don't want to write any more {prop}ing numbers ({i + 1})", new object[] { new { twenty_one = 21, twenty_two = 22 }, new { twenty_three = 23 } })
 			.Should()
 			.HaveCount(23);
-	}
 
 	[Test]
 	public void Count()


### PR DESCRIPTION
Using Booleans as DbType fields currently triggers an exception `Failed to cast System.UInt64 to System.Boolean.` because UInt64 has no `operator bool`, but it is possible to convert from UInt64 to boolean using Convert.